### PR TITLE
read the whole file for CST construction

### DIFF
--- a/fast_ms/.vscode/launch.json
+++ b/fast_ms/.vscode/launch.json
@@ -5,6 +5,29 @@
     "version": "0.2.0",
     "configurations": [
     {
+        "name": "(gdb) matching_stats_parallel",
+        "type": "cppdbg",
+        "request": "launch",
+        "program": "${workspaceFolder}/bin/matching_stats_parallel.x",
+        "args": [
+            "-s_path", "${workspaceFolder}/ss",
+            "-t_path", "${workspaceFolder}/tt",
+        ],
+        "stopAtEntry": false,
+        "cwd": "${workspaceFolder}",
+        "environment": [],
+        "externalConsole": false,
+        "MIMode": "gdb",
+        "setupCommands": [
+            {
+                "description": "Enable pretty-printing for gdb",
+                "text": "-enable-pretty-printing",
+                "ignoreFailures": true
+            }
+        ],
+        "preLaunchTask": "build matching_stats_parallel"
+    },
+    {
         "name": "(gdb) range queries profile",
         "type": "cppdbg",
         "request": "launch",

--- a/fast_ms/src/fd_ms/input_spec.hpp
+++ b/fast_ms/src/fd_ms/input_spec.hpp
@@ -67,10 +67,10 @@ namespace fdms {
 
         string load_s(bool reverse = false) const {
             string s;
-            std::ifstream s_file{s_fname};
-            while (s_file >> s)
-                ;
-
+            char ch{};
+            std::ifstream s_file{s_fname, ios::binary | ios::in};
+            while (s_file.get(ch))
+                s += ch;
             if (reverse)
                 reverse_in_place(s);
             return s;
@@ -102,7 +102,7 @@ namespace fdms {
             size_t suff_len = 5; // '.ridx'.size()
             size_t l = ms_fname.size();
 
-            string s = ridx_fname.substr(l + 1, 
+            string s = ridx_fname.substr(l + 1,
                     ridx_fname.size() - (l + 1) - suff_len);
             return static_cast<size_t> (std::stoi(s));
         }


### PR DESCRIPTION
The error in #100 has 2 causes. The main cause is that the program (inadvertently) expects the input to (1) have no spaces and (2) be in a single line. This PR changes the behavior to read the whole file verbatim (minus the final newline that most text editors will add automatically).

The other cause is that there are symbols in the target file (`README.md` in this case) that do not appear in the query file (`makefile` in this case). The symbols should be <code>[]\`~</code>This is an expected behavior, though we plan to support this case in the future. 